### PR TITLE
fix(template): 장바구니 선택 항목 수 초기 표시 수정

### DIFF
--- a/templates/_bundled/sirsoft-basic/layouts/partials/shop/_cart_list.json
+++ b/templates/_bundled/sirsoft-basic/layouts/partials/shop/_cart_list.json
@@ -54,7 +54,7 @@
                   "type": "basic",
                   "name": "Span",
                   "props": { "className": "text-sm text-gray-500 dark:text-gray-400" },
-                  "text": "({{_local.selectedCount}}/{{cartItems.data.items.length}})"
+                  "text": "({{_local.selectedItems?.length ?? 0}}/{{cartItems.data.items?.length ?? 0}})"
                 }
               ]
             },


### PR DESCRIPTION
## 변경 내용

장바구니 최초 진입 시 선택 항목 수가 빈 값으로 표시되는 문제를 수정합니다.

- `_local.selectedCount` 대신 `_local.selectedItems.length`를 사용합니다.
- 데이터가 아직 없을 때는 `0`으로 표시합니다.
- API와 DB 동작은 변경하지 않습니다.

## 검증

- 최초 진입: `(27/27)`
- 전체 선택 해제: `(0/27)`
- 다시 전체 선택: `(27/27)`

Fixes #92